### PR TITLE
FSM 구조 추가

### DIFF
--- a/Assets/Scripts/Util/FSM.meta
+++ b/Assets/Scripts/Util/FSM.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 03c0c5b5e4ced4be1a7f7f4299aa5f2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/FSM/Editor.meta
+++ b/Assets/Scripts/Util/FSM/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c23a138bce1e304b83becca61404bc4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/FSM/Editor/FSMPlayerEditor.cs
+++ b/Assets/Scripts/Util/FSM/Editor/FSMPlayerEditor.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using UnityEditor;
+using System.Linq;
+
+namespace QT
+{
+    [CustomEditor(typeof(FSMPlayer<>), true)]
+    public class FSMPlayerEditor : Editor
+    {
+        private Type _targetType = null;
+
+        private int _statePopupIndex = 0;
+        private string _currentStateName = "";
+
+
+        protected void OnEnable()
+        {
+            SceneView.duringSceneGui += this.OnSceneGUI;
+
+            _targetType = target.GetType();
+            while (_targetType.BaseType != typeof(MonoBehaviour))
+            {
+                _targetType = _targetType.BaseType;
+            }
+        }
+
+        protected void OnDisable()
+        {
+            SceneView.duringSceneGui -= this.OnSceneGUI;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            ShowStateInfo();
+
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+
+        private void OnSceneGUI(SceneView sceneView)
+        {
+            var transform = ((MonoBehaviour)target).transform;
+            Handles.Label(transform.position + Vector3.up, _currentStateName);
+        }
+
+
+        private void ShowStateInfo()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            _currentStateName = GetTypeName(GetValue("currentState"));
+            var previousStateName = GetTypeName(GetValue("previousState"));
+            var globalStateName = GetTypeName(GetValue("globalState"));
+
+            var ids = new List<int>();
+            var names = new List<string>();
+            SetStateList((dynamic)GetValue("states"), ids, names, _currentStateName);
+
+
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.Height(55));
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.Label($"GLOBAL : ", EditorStyles.whiteLargeLabel, GUILayout.Width(100));
+            GUILayout.Label($"{globalStateName}", EditorStyles.largeLabel, GUILayout.ExpandWidth(false));
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+
+            GUILayout.Label("PreviousState : ", EditorStyles.whiteLargeLabel, GUILayout.Width(100));
+            GUILayout.Label($"{previousStateName}", EditorStyles.largeLabel, GUILayout.ExpandWidth(false));
+
+
+            GUILayout.Label("➜", EditorStyles.whiteLargeLabel, GUILayout.Width(20));
+
+            GUILayout.Label("CurrentState : ", EditorStyles.whiteLargeLabel, GUILayout.Width(100));
+            int newValue = EditorGUILayout.Popup(_statePopupIndex, names.ToArray());
+
+            if (newValue != _statePopupIndex)
+            {
+                _statePopupIndex = newValue;
+                _targetType.GetMethod("ChangeState").Invoke(target, new object[1] { ids[_statePopupIndex] });
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.EndVertical();
+        }
+
+        private object GetValue(string fieldName)
+        {
+            return _targetType.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Default)?.GetValue(target);
+        }
+
+        private string GetTypeName(object type)
+        {
+            return type?.ToString()?.Split('.')[^1] ?? "None";
+        }
+
+        private void SetStateList<T>(Dictionary<int, T> states, List<int> ids, List<string> names, string currentStateName)
+        {
+            var keys = states.Keys.ToList();
+            var values = states.Values.ToList();
+            for (int i = 0; i < states.Count; i++)
+            {
+                var name = GetTypeName(values[i]);
+                names.Add(name);
+                ids.Add(keys[i]);
+
+                if (name == currentStateName)
+                {
+                    _statePopupIndex = i;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Util/FSM/Editor/FSMPlayerEditor.cs.meta
+++ b/Assets/Scripts/Util/FSM/Editor/FSMPlayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfda3f952bb0acc4abbdc7e55836a9e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/FSM/FSMPlayer.cs
+++ b/Assets/Scripts/Util/FSM/FSMPlayer.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+
+namespace QT
+{
+    public interface IFSMEntity
+    {
+
+    }
+
+    public abstract class FSMPlayer<T> : MonoBehaviour where T : IFSMEntity
+    {
+        private Dictionary<int, FSMState<T>> _states;
+
+        private FSMState<T> _currentState = null;
+        private FSMState<T> _previousState = null;
+        private FSMState<T> _globalState = null;
+
+        protected virtual void Update()
+        {
+            _globalState?.UpdateState();
+            _currentState?.UpdateState();
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            _globalState?.FixedUpdateState();
+            _currentState?.FixedUpdateState();
+        }
+
+        protected void SetUp(ValueType firstState)
+        {
+            _states = new Dictionary<int, FSMState<T>>();
+            var stateTypes = Assembly.GetExecutingAssembly().GetTypes().Where(t => typeof(FSMState<T>) != t && typeof(FSMState<T>).IsAssignableFrom(t));
+
+            foreach (var stateType in stateTypes)
+            {
+                var attribute = stateType.GetCustomAttribute<FSMStateAttribute>();
+
+                if (attribute == null)
+                {
+                    continue;
+                }
+
+                var state = Activator.CreateInstance(stateType, this as IFSMEntity) as FSMState<T>;
+
+                if (!_states.TryAdd(attribute.Key, state))
+                {
+                    Debug.LogError($"{typeof(T)} 의 {attribute.Key} 키가 중복되었습니다.");
+                }
+            }
+
+            ChangeState(firstState);
+        }
+
+        public void ChangeState(ValueType enumValue)
+        {
+            if (!_states.TryGetValue((int)enumValue, out var state))
+            {
+                Debug.LogError($"{GetType()} : 사용할 수 없는 상태입니다. {enumValue}");
+                return;
+            }
+
+            ChangeState(state);
+        }
+
+        private void ChangeState(FSMState<T> newState)
+        {
+            if (newState == null) return;
+
+            if (_currentState != null)
+            {
+                _previousState = _currentState;
+
+                _currentState.ClearState();
+
+                Debug.Log($"{this.GetType()} : {_currentState.GetType()} 상태 클리어");
+            }
+
+            _currentState = newState;
+            _currentState.InitializeState();
+
+
+
+            Debug.Log($"{this.GetType()} : {newState.GetType()} 상태로 전환");
+        }
+
+        public void SetGlobalState(FSMState<T> newState)
+        {
+            _globalState?.ClearState();
+
+            _globalState = newState;
+
+            _globalState?.InitializeState();
+        }
+
+        public void RevertToPreviousState()
+        {
+            ChangeState(_previousState);
+        }
+    }
+}

--- a/Assets/Scripts/Util/FSM/FSMPlayer.cs.meta
+++ b/Assets/Scripts/Util/FSM/FSMPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b41dd48639aba014098e1413e2991c16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/FSM/FSMState.cs
+++ b/Assets/Scripts/Util/FSM/FSMState.cs
@@ -1,0 +1,32 @@
+using System;
+
+
+namespace QT
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class FSMStateAttribute : System.Attribute
+    {
+        public readonly int Key;
+
+        public FSMStateAttribute(int key)
+        {
+            this.Key = key;
+        }
+    }
+
+
+    public abstract class FSMState<T> where T : IFSMEntity
+    {
+        protected readonly T _ownerEntity;
+
+        public virtual void InitializeState() { }
+        public virtual void UpdateState() { }
+        public virtual void FixedUpdateState() { }
+        public virtual void ClearState() { }
+
+        public FSMState(IFSMEntity owner)
+        {
+            _ownerEntity = (T)owner;
+        }
+    }
+}

--- a/Assets/Scripts/Util/FSM/FSMState.cs.meta
+++ b/Assets/Scripts/Util/FSM/FSMState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af3dc446daccce348b29389e32c7fe52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## FSM 구조

최대한 쓰기 편한 구조를 생각하며 설계함

### IFSMEntity

FSM엔티티라는 것을 나타내는 인터페이스

오로지 구분을 위해 만든 인터페이스라 내용은 비어있음

### FSMPlayer

상태들을 관리하는 엔티티  

`SetUp()` 과정에서 `IFSMEntity`를 타겟으로 하는 `FSMState` 들을 찾아  
상태들을 생성해 저장
- FSMState 타입들을 캐싱해야 할 듯

이때 생성된 상태들은 `_states` 딕셔너리에 지정된 key값과 함께 저장

- `ChangeState(ValueType)` : 해당 키에 맞는 상태로 전환하기
- `SetGlobalState(SFMState<T>)` : 글로벌 상태 지정
    - GlobalState는 따로 생성해 집어넣어야 함


### FSMState

엔티티가 사용하는 상태

- `InitializeState()` : 상태가 전환되었을때 초기화
- `UpdateState()` : `MonoBehavior`의  Update 이벤트에서 호출
- `FixedUpdateState()` : MonoBehavior`의  FixedUpdate 이벤트에서 호출
    - 필요 없다면 삭제 가능성 있음
- `ClearState()` : 상태가 끝날때 호출

### FSMStateAttribute

해당 상태의 `key`를 지정해주는 어트리뷰트

#### Player 예시
```C#
public class Player : FSMPlayer<Player>, IFSMEntity
{
    public enum States : int
    {
        Global,
        Move,
    }

    public void Awake()
    {
        SetUp(States.Move);
        SetGlobalState(new PlayerGlobalState(this)); // Global 스테이트는 따로 생성해 넣어줘야 함
    }
}
```


#### State 예시
```C#
[FSMState((int) Player.States.Move)]
public class PlayerMoveState : FSMState<Player>
{
    public PlayerMoveState(IFSMEntity owner) : base(owner) // 생성자 필수...
    {
    }

    public override void InitializeState()
    {
        ...
    }
}
```


<br>
<br>

## FSM 에디터

### 현재 상태 보기 및 수동 변경

![image](https://user-images.githubusercontent.com/96484044/225109835-ab008209-d973-4ca6-b66a-09377d5c676f.png)

현재 FSMPlayer의 globalState, previousState, currentState 를 확인하고
currentState 를 수동으로 변경할 수 있음

#### FSMPlayer 타입 가져오기

`FSMPlayer`는 제네릭 클래스이기 때문에 `target`의 FSMPlayer가 정확히 어떤 값인지 가져오기 어려웠음
`target` 타입의 `BaseType`를 `MonoBehavior`이 나올때 까지 타고 타고 올라가 `FSMPlayer` 타입을 구해낼 수 있었음


#### 현재 상태 가져오기

`FSMPlayer`에서 state 정보는 private 처리되어 있기 때문에
리플렉션을 사용해 타입만을 가져와 타입명을 표시하였음

#### 모든 상태 가져오기

모든 state 정보를 담고 있는`states` 딕셔너리의 Value는 제네릭 인자를 사용하기 때문에
딕셔너리의 값들을 제대로 가져올 수 없던 문제가 있었음

딕셔너리의 정보를 읽는 제네릭 함수를 만들고
`states` 오브젝트를 dynamic으로 넘겨줘 `T`의 타입을 가져올 수 있었음

딕셔너리의 Key값은 `ChangeState()`를 호출하는 용도로 사용

https://stackoverflow.com/a/13608657

### 레이블

![image](https://user-images.githubusercontent.com/96484044/225111987-0510ed4e-d45a-49b7-8423-324b15315bc9.png)

현재 `FSMPlayer` 를 사용하는 모든 엔티티의 상태를 표시함

`target`의 포지션 기준 y 좌표 1 위에 표시
(보통 엔티티의 좌표가 바닥 기준이기 때문에 약간 위로 올림)