### PR TITLE
FSM글로벌 상태 예외처리

### DIFF
--- a/Assets/Scripts/Enemy/States/EnemyGlobalState.cs
+++ b/Assets/Scripts/Enemy/States/EnemyGlobalState.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace QT.Enemy
 {
-    [FSMState((int)Enemy.States.Global)]
+    [FSMState((int)Enemy.States.Global, false)]
     public class EnemyGlobalState : FSMState<Enemy>
     {
         public EnemyGlobalState(IFSMEntity owner) : base(owner)

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -52,7 +52,7 @@ namespace QT.Player
             SetUpStats();
             SwingAreaCreate();
             SetUp(States.Idle);
-            SetGlobalState(States.Global);
+            SetGlobalState(new PlayerGlobalState(this));
 
             _playerSystem = GameManager.Instance.GetSystem<PlayerSystem>();
         }

--- a/Assets/Scripts/Player/States/PlayerGlobalState.cs
+++ b/Assets/Scripts/Player/States/PlayerGlobalState.cs
@@ -5,7 +5,7 @@ using QT.Core.Input;
 
 namespace QT.Player
 {
-    [FSMState((int)Player.States.Global)]
+    [FSMState((int)Player.States.Global, false)]
     public class PlayerGlobalState : FSMState<Player>
     {
         private InputSystem _inputSystem;
@@ -108,12 +108,12 @@ namespace QT.Player
             _ownerEntity.BatSpriteRenderOnOff(true);
             if (_currentChargingTime <= _ownerEntity.ChargeTimes[0].Value)
             {
-                // ÀÏ¹Ý½ºÀ®
+                // ??????
                 _ownerEntity.AttackBatSwing(_currentChargingTime, () => { _currentSwingCoolTime = 0f;});
             }
             else
             {
-                // Â÷Â¡½ºÀ®
+                // ??¢®????
                 _ownerEntity.ChargingBatSwing(_currentChargingTime,() => { _currentSwingCoolTime = 0f;});
             }
             _currentChargingTime = 0f;

--- a/Assets/Scripts/Util/FSM/FSMPlayer.cs
+++ b/Assets/Scripts/Util/FSM/FSMPlayer.cs
@@ -43,7 +43,7 @@ namespace QT.Core
             {
                 var attribute = stateType.GetCustomAttribute<FSMStateAttribute>();
 
-                if (attribute == null)
+                if (attribute == null || !attribute.IncludeStates)
                 {
                     continue;
                 }
@@ -93,18 +93,13 @@ namespace QT.Core
             return _currentState;
         }
 
-        public void SetGlobalState(ValueType enumValue)
+        public void SetGlobalState(FSMState<T> state)
         {
-            //_globalState?.ClearState();
-            if (!_states.TryGetValue((int) enumValue, out var state)) // TODO : GlobalState가 시작할때 두번 로드하는 버그가 생겨서 임시로 수정함
-            {
-                Debug.LogError($"{GetType()} : 사용할 수 없는 상태입니다. {enumValue}");
-                return;
-            }
-
+            _globalState?.ClearState();
+            
             _globalState = state;
 
-            //_globalState?.InitializeState();
+            _globalState?.InitializeState();
         }
 
         public void RevertToPreviousState()

--- a/Assets/Scripts/Util/FSM/FSMState.cs
+++ b/Assets/Scripts/Util/FSM/FSMState.cs
@@ -7,10 +7,12 @@ namespace QT.Core
     public class FSMStateAttribute : System.Attribute
     {
         public readonly int Key;
+        public readonly bool IncludeStates;
 
-        public FSMStateAttribute(int key)
+        public FSMStateAttribute(int key, bool includeStates = true)
         {
             this.Key = key;
+            this.IncludeStates = IncludeStates;
         }
     }
 


### PR DESCRIPTION
fsmPlayer에서 글로벌 상태를 사용할 때 

글로벌로만 사용할 상태가
`SetUp()`과정과 `SetGlobalState()`를 설정하는 부분 2 곳에서 모두 생성되는 문제가 있었음

`FSMStateAttribute`에 SetUp과정에서 추가하지 않는다는 표시 (`includeStates`)를 추가해 해결