### PR TITLE
스케일 및 스케일에 따른 콜라이더/사이즈 조정

### DIFF
--- a/Assets/Arts/Animations/M_Baseball_Catcher/Monster_Catcher4_SkeletonData.asset
+++ b/Assets/Arts/Animations/M_Baseball_Catcher/Monster_Catcher4_SkeletonData.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   atlasAssets:
   - {fileID: 11400000, guid: bd270ea6f7b5d50408491eb702ad3de1, type: 2}
-  scale: 0.005
+  scale: 0.00512
   skeletonJSON: {fileID: 4900000, guid: f94b36a8341c64a4f90ab3771d146a72, type: 3}
   isUpgradingBlendModeMaterials: 0
   blendModeMaterials:

--- a/Assets/Arts/Animations/Player_Oni/Player_Oni/player_0416.png.meta
+++ b/Assets/Arts/Animations/Player_Oni/Player_Oni/player_0416.png.meta
@@ -39,15 +39,15 @@ TextureImporter:
     wrapU: 0
     wrapV: 0
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 256
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -76,7 +76,7 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-    forceMaximumCompressionQuality_BC6H_BC7: 1
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Standalone
     maxTextureSize: 2048
@@ -88,14 +88,38 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-    forceMaximumCompressionQuality_BC6H_BC7: 1
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Arts/Animations/Player_Oni/Player_Oni/player_0416_SkeletonData.asset
+++ b/Assets/Arts/Animations/Player_Oni/Player_Oni/player_0416_SkeletonData.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   atlasAssets:
   - {fileID: 11400000, guid: 65b463a051a39f146b04825324698d7c, type: 2}
-  scale: 0.01
+  scale: 0.00512
   skeletonJSON: {fileID: 4900000, guid: aff599dfb4cd1554e80d46d8901c40c3, type: 3}
   isUpgradingBlendModeMaterials: 0
   blendModeMaterials:

--- a/Assets/Arts/Animations/Player_Oni/bat/bat.png.meta
+++ b/Assets/Arts/Animations/Player_Oni/bat/bat.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 9
   spritePivot: {x: 0.5, y: 0.25}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 256
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -91,6 +91,18 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Arts/Prefabs/Enemy/Enemy_Catcher.prefab
+++ b/Assets/Arts/Prefabs/Enemy/Enemy_Catcher.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1441922973836523936}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.409, z: 0}
+  m_LocalPosition: {x: 0, y: 0.3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -57,7 +57,7 @@ Transform:
   m_GameObject: {fileID: 6119265654750196061}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.3, y: 0.5, z: 1}
+  m_LocalScale: {x: 1.2, y: 0.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3026859772209166903}
@@ -144,7 +144,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8156516132694055129}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.492, z: 0}
+  m_LocalPosition: {x: 0, y: 0.512, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Arts/Prefabs/Enemy/Enemy_Catcher2.prefab
+++ b/Assets/Arts/Prefabs/Enemy/Enemy_Catcher2.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1441922973836523936}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.44, z: 0}
+  m_LocalPosition: {x: 0, y: 0.3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -57,7 +57,7 @@ Transform:
   m_GameObject: {fileID: 6119265654750196061}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.3, y: 0.5, z: 1}
+  m_LocalScale: {x: 1.2, y: 0.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3026859772209166903}
@@ -144,7 +144,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8156516132694055129}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.525, z: 0}
+  m_LocalPosition: {x: 0, y: 0.512, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -349,8 +349,8 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.48}
-  m_Size: {x: 1.03, y: 0.81}
+  m_Offset: {x: 0, y: 0.42}
+  m_Size: {x: 0.97, y: 0.22}
   m_Direction: 0
 --- !u!114 &2344846795604620376
 MonoBehaviour:

--- a/Assets/Arts/Prefabs/EnemyProjectile.prefab
+++ b/Assets/Arts/Prefabs/EnemyProjectile.prefab
@@ -25,8 +25,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4739556359036921218}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0.2, z: 0}
+  m_LocalScale: {x: 1.429, y: 1.429, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2996694689170404483}
@@ -111,7 +111,7 @@ Transform:
   m_GameObject: {fileID: 8292683858384144843}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.7, y: 0.3, z: 1}
+  m_LocalScale: {x: 0.2541157, y: 0.10890673, z: 0.36302242}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9054224182170156286}
@@ -216,11 +216,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7fd102d3b01194134bb35005c032df13, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _ballHeight: 1
-  _ballObject: {fileID: 4417902253488565075}
   _bounceMask:
     serializedVersion: 2
     m_Bits: 1280
+  _ballHeight: 0.2
+  _ballObject: {fileID: 4417902253488565075}
 --- !u!210 &1986756428296105485
 SortingGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Arts/Prefabs/Player.prefab
+++ b/Assets/Arts/Prefabs/Player.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 404674089569222766}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.9, z: 0}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -252,7 +252,7 @@ Transform:
   m_GameObject: {fileID: 5588212210452170156}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.53, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7781006472481742598}
@@ -459,7 +459,7 @@ Transform:
   m_GameObject: {fileID: 7781006471382150578}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.06, y: 0.35, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 874304521411244145}
@@ -623,7 +623,7 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.3}
+  m_Offset: {x: 0, y: 0.1}
   m_Size: {x: 0.6, y: 0.6}
   m_Direction: 0
 --- !u!114 &3347244131815535560

--- a/Assets/Arts/Prefabs/PlayerProjectile.prefab
+++ b/Assets/Arts/Prefabs/PlayerProjectile.prefab
@@ -25,8 +25,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4739556359036921218}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0.4, z: 0}
+  m_LocalScale: {x: 1.429, y: 1.429, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2996694689170404483}
@@ -111,7 +111,7 @@ Transform:
   m_GameObject: {fileID: 8292683858384144843}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.7, y: 0.3, z: 1}
+  m_LocalScale: {x: 0.48972, y: 0.20988001, z: 0.6996}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9054224182170156286}
@@ -216,11 +216,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7fd102d3b01194134bb35005c032df13, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _ballHeight: 1
-  _ballObject: {fileID: 4417902253488565075}
   _bounceMask:
     serializedVersion: 2
     m_Bits: 1280
+  _ballHeight: 0.4
+  _ballObject: {fileID: 4417902253488565075}
 --- !u!210 &1986756428296105485
 SortingGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Arts/Sprites/Objects/Ob_Ball.png.meta
+++ b/Assets/Arts/Sprites/Objects/Ob_Ball.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 256
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -91,6 +91,18 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1


### PR DESCRIPTION
- 각 투사체 높이 조정(플레이어는 좀 낮게, 적 투사체는 완전 낮게 콜라이더 차이 없게)
- 적 콜라이더 일관화
- 공 PPU 조정 및 스케일 사이즈 맞춤
- 캐릭터 PPU조정 및 스케일 사이즈 맞춤 (PPU 512의 절반크기), 스케일1로 변경
- 적 슛포인트 위치 조정
- 적 그림자 크기 조정