### PR TITLE
UI, 시스템 로직 버그 픽스

### DIFF
--- a/Assets/Scenes/RDScene/DataLoadScene.unity
+++ b/Assets/Scenes/RDScene/DataLoadScene.unity
@@ -343,7 +343,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.5019608}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scripts/Player/States/PlayerDodgeState.cs
+++ b/Assets/Scripts/Player/States/PlayerDodgeState.cs
@@ -20,6 +20,7 @@ namespace QT.InGame
         public void InitializeState(Vector2 dir)
         {
             _ownerEntity.GetStatus(PlayerStats.DodgeCooldown).SetStatus(0);
+            _ownerEntity.GetStatus(PlayerStats.DodgeInvincibleTime).SetStatus(0);
             _ownerEntity.Animator.SetTrigger(AnimationDodgeHash);
 
             float tempX = dir.x;

--- a/Assets/Scripts/Player/States/PlayerMoveState.cs
+++ b/Assets/Scripts/Player/States/PlayerMoveState.cs
@@ -19,7 +19,7 @@ namespace QT.InGame
         {
             _ownerEntity.OnMove = OnMove;
             _ownerEntity.SetAction(Player.ButtonActions.Swing, OnSwing);
-            _ownerEntity.SetAction(Player.ButtonActions.Throw, OnThrow);
+            //_ownerEntity.SetAction(Player.ButtonActions.Throw, OnThrow);
             _ownerEntity.SetAction(Player.ButtonActions.Dodge, OnDodge);
 
             _moveDirection = Vector2.zero;
@@ -29,7 +29,7 @@ namespace QT.InGame
         {
             _ownerEntity.OnMove = null;
             _ownerEntity.ClearAction(Player.ButtonActions.Swing);
-            _ownerEntity.ClearAction(Player.ButtonActions.Throw);
+            //_ownerEntity.ClearAction(Player.ButtonActions.Throw);
             _ownerEntity.ClearAction(Player.ButtonActions.Dodge);
             
             _ownerEntity.Rigidbody.velocity = Vector2.zero;


### PR DESCRIPTION
- 미니맵 캔버스 투명도 0.5로조절
- 플레이어 회피 무적 미적용 수정
- 플레이어 던지기 시스템 임시 비활성화