### PR TITLE
디버그 콘솔 띄우는 조건 수정

### DIFF
--- a/Assets/Scripts/System/SystemManager.cs
+++ b/Assets/Scripts/System/SystemManager.cs
@@ -42,8 +42,14 @@ namespace QT.Core
             _PostInitializeSystems();
             
             UIManager?.PostSystemInitialize();
+
+#if Testing
+
+            _debugConsole.SetActive(true);
+#else
+            _debugConsole.SetActive(false);   
+#endif
             
-            _debugConsole.SetActive(Debug.isDebugBuild);
         }
 
         private void InitializeSystems()


### PR DESCRIPTION
디버그 콘솔 띄우는 조건 
`isDebugBuild `가 아니라 `Testing` 디파인으로 구분