### PR TITLE
아이템 이펙트 에러 수정

### DIFF
--- a/Assets/Arts/UI/Prefab/InventoryCanvas.prefab
+++ b/Assets/Arts/UI/Prefab/InventoryCanvas.prefab
@@ -3252,8 +3252,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -36.4, y: -23}
-  m_SizeDelta: {x: 166.2073, y: 142.9812}
+  m_AnchoredPosition: {x: -43.3, y: -23}
+  m_SizeDelta: {x: 208.453, y: 142.981}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1770591164562253045
 CanvasRenderer:

--- a/Assets/Scripts/Item/Inventory.cs
+++ b/Assets/Scripts/Item/Inventory.cs
@@ -27,11 +27,11 @@ namespace QT.InGame
             playerManager.OnGoldValueChanged.AddListener((value) =>
                 InvokeApplyPoint(ItemEffectGameData.ApplyPoints.OnGoldChanged));
             
-            // _targetPlayer.GetStat(PlayerStats.MovementSpd).OnValueChanged
-            //     .AddListener(() => InvokeApplyPoint(ItemEffectGameData.ApplyPoints.OnMovementSpdChanged));
-            //
-            // _targetPlayer.GetStat(PlayerStats.ChargeBounceCount2).OnValueChanged
-            //     .AddListener(() => InvokeApplyPoint(ItemEffectGameData.ApplyPoints.OnChargeBounceCountChanged));
+            _targetPlayer.GetStat(PlayerStats.MovementSpd).OnValueChanged
+                .AddListener(() => InvokeApplyPoint(ItemEffectGameData.ApplyPoints.OnMovementSpdChanged));
+            
+            _targetPlayer.GetStat(PlayerStats.ChargeBounceCount2).OnValueChanged
+                .AddListener(() => InvokeApplyPoint(ItemEffectGameData.ApplyPoints.OnChargeBounceCountChanged));
         }
 
         private void InvokeApplyPoint(ItemEffectGameData.ApplyPoints applyPoints)

--- a/Assets/Scripts/Item/ItemEffect/ItemEffectStat.cs
+++ b/Assets/Scripts/Item/ItemEffect/ItemEffectStat.cs
@@ -91,8 +91,6 @@ namespace QT
                 
                 Stat stat = player.GetStat(param.Item1);
 
-                stat.RemoveAllModifiersFromSource(source);
-                
                 if(stat is Status)
                 {
                     value = param.Item2 == StatValueType.Base ? (stat as Status).Value : (stat as Status).StatusValue;


### PR DESCRIPTION
### 특정 스탯 변경 applyPoint 때문에 스택 오버플로우 에러 나던거 수정
- applyvalue에서 인자로 사용하는 스탯을 가져올때 굳이 모디파이어를 건드린게 문제였음


### 기타
- 인벤토리 캔버스 설명 표시 영역 늘림