### PR TITLE
Time.time 제거

### DIFF
--- a/Assets/Scripts/Enemy/Enemy/States/EnemyProjectileState.cs
+++ b/Assets/Scripts/Enemy/Enemy/States/EnemyProjectileState.cs
@@ -36,8 +36,8 @@ namespace QT.InGame
         private float _damage;
         
         private bool _isReleased;
-        private float _releaseStartTime;
         private float _releaseDelay;
+        private float _releaseTimer;
         
         
         private Transform _transform;
@@ -100,7 +100,8 @@ namespace QT.InGame
         
         public override void UpdateState()
         {
-            if (_isReleased && Time.time - _releaseStartTime >= _releaseDelay)
+            _releaseTimer += Time.deltaTime;
+            if (_isReleased && _releaseTimer > _releaseDelay)
             {
                 _ownerEntity.ChangeState(Enemy.States.Dead);
             }
@@ -165,7 +166,8 @@ namespace QT.InGame
                     {
                         _isReleased = true;
                     }
-                    _releaseStartTime = Time.time;
+
+                    _releaseTimer = 0;
 
                     if (_releaseDelay > 0)
                     {
@@ -193,14 +195,14 @@ namespace QT.InGame
                     {
                         _ownerEntity.HP.SetStatus(0);
                         _isReleased = true;
-                        _releaseStartTime = Time.time;
+                        _releaseTimer = 0;
                         _ownerEntity.ChangeState(Enemy.States.Dead);
                         return;
                     }
                     if (_ownerEntity.HP <= 0)
                     {
                         _isReleased = true;
-                        _releaseStartTime = Time.time;
+                        _releaseTimer = 0;
 
                         _speed = MinSpeed;
                     }

--- a/Assets/Scripts/Enemy/Enemy/States/EnemyRigidState.cs
+++ b/Assets/Scripts/Enemy/Enemy/States/EnemyRigidState.cs
@@ -11,8 +11,8 @@ namespace QT.InGame
         private static readonly int RigidAnimHash = Animator.StringToHash("IsRigid");
         private const string TeleportLinePath = "Prefabs/TeleportLine.prefab";
 
-        private float _rigidStartTime;
         private float _rigidTime;
+        private float _rigidTimer;
 
         private SoundManager _soundManager;
         private GlobalDataSystem _globalDataSystem;
@@ -24,14 +24,14 @@ namespace QT.InGame
             _globalDataSystem = SystemManager.Instance.GetSystem<GlobalDataSystem>();
             _playerManager.PlayerMapClearPosition.AddListener((arg) =>
             {
-                _rigidTime = 0f;
+                _rigidTimer = _rigidTime;
             });
         }
 
         public override void InitializeState()
         {
             _ownerEntity.Animator.SetBool(RigidAnimHash, true);
-            _rigidStartTime = Time.time;
+            _rigidTimer = 0;
 
             if (_ownerEntity.HP <= 0)
             {
@@ -67,7 +67,8 @@ namespace QT.InGame
 
         public override void UpdateState()
         {
-            if (_rigidStartTime + _rigidTime < Time.time)
+            _rigidTimer += Time.deltaTime;
+            if (_rigidTimer > _rigidTime)
             {
                 if (_ownerEntity.HP <= 0)
                 {

--- a/Assets/Scripts/Projectile/Projectile.cs
+++ b/Assets/Scripts/Projectile/Projectile.cs
@@ -56,8 +56,8 @@ namespace QT.InGame
         private float _damage;
 
         private bool _isReleased;
-        private float _releaseStartTime;
         private float _releaseDelay;
+        private float _releaseTimer;
 
         private float _reflectCorrection;
         private Transform _playerTransform;
@@ -196,7 +196,8 @@ namespace QT.InGame
         
         private void Update()
         {
-            if (_isReleased && Time.time - _releaseStartTime >= _releaseDelay)
+            _releaseTimer += Time.deltaTime;
+            if (_isReleased && _releaseTimer > _releaseDelay)
             {
                 SystemManager.Instance.ResourceManager.ReleaseObject(_prefabPath, this);
                 TrailRendersSetEmitting(false);
@@ -265,7 +266,7 @@ namespace QT.InGame
                 if (!_isReleased && --_bounceCount <= 0)
                 {
                     _isReleased = true;
-                    _releaseStartTime = Time.time;
+                    _releaseTimer = 0;
 
                     if (_releaseDelay > 0)
                     {
@@ -339,7 +340,7 @@ namespace QT.InGame
                 if (!_isReleased && --_bounceCount <= 0)
                 {
                     _isReleased = true;
-                    _releaseStartTime = Time.time;
+                    _releaseTimer = 0;
 
                     if (_releaseDelay > 0)
                     {
@@ -364,7 +365,7 @@ namespace QT.InGame
                 if (_speed <= 0)
                 {
                     _isReleased = true;
-                    _releaseStartTime = Time.time;
+                    _releaseTimer = 0;
                 
                     _speed = MinSpeed;
                 }


### PR DESCRIPTION
굳이 사용할 필요가 없는 Time.time 제거
(Time.time은 정밀도 이슈가 생길 수 있으므로 지양하는게 좋다고 생각합니다.)

https://discussions.unity.com/t/hypothetical-what-happens-if-time-time-overflows/103827/5