### PR TITLE
맵 저장할 때 타일맵 색깔 문제 수정

### DIFF
--- a/Assets/Scripts/Map/MapEditor/Editor/MapEditor.cs
+++ b/Assets/Scripts/Map/MapEditor/Editor/MapEditor.cs
@@ -283,7 +283,7 @@ namespace QT.Map
                 if (!string.IsNullOrWhiteSpace(path))
                 {
                     CompressMapCell();
-                    
+
                     if(PrefabUtility.IsOutermostPrefabInstanceRoot(_target.gameObject))
                     {
                         PrefabUtility.UnpackPrefabInstance(_target.gameObject, PrefabUnpackMode.OutermostRoot, InteractionMode.UserAction);
@@ -305,10 +305,12 @@ namespace QT.Map
 
         private void CompressMapCell()
         {
+            _target.transform.position = Vector3.zero;
             var targets = FindObjectsOfType<Tilemap>();
 
             foreach (var target in targets)
             {
+                target.color = Color.white;
                 target.CompressBounds();
             }
         }


### PR DESCRIPTION
타일맵 저장할 때

타일맵 도구 선택으로 색깔이 어두워진 경우 그 색깔 그대로 저장되던 문제 수정